### PR TITLE
Fix PR link

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,10 +53,6 @@ runs:
       working-directory: napari-hub/frontend
       run: yarn install
 
-    - name: Fetch PR url
-      id: pr-url
-      uses: kceb/pull-request-url-action@v1
-
     - name: Build the preview page
       shell: bash
       run: yarn build:preview
@@ -64,7 +60,7 @@ runs:
       env:
         BASE_PATH: /${{ github.repository }}/${{ github.event.pull_request.number }}
         PREVIEW: preview.json
-        PREVIEW_PULL_REQUEST: ${{ steps.pr-url.outputs.url }}
+        PREVIEW_PULL_REQUEST: https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
     - name: Upload preview page artifact
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
The PR link for the preview page currently isn't working. Instead, it opens a new link with of the same page:

https://user-images.githubusercontent.com/2176050/140138682-43771d85-9320-43f3-98bf-5fbcbd2c03c8.mp4

The issue is that the `href` attribute for the link is being passed an empty string:

![image](https://user-images.githubusercontent.com/2176050/140139592-cf873839-595c-4c86-aa00-0ce5e42b214e.png)

This leads me to believe that [kceb/pull-request-url-action](https://github.com/kceb/pull-request-url-action) is not working as expected. Instead of using a separate action getting the URL, we can pass it directly using the GitHub event data.
