### PR TITLE
Add instructions and link back to the main guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # napari hub preview action
 
-This is a GitHub action to generate preview page for napari hub plugin
+This GitHub action generates a napari hub plugin preview page and produces the static page as
+an artifact.
 
+To view your plugin as it would appear on the napari hub, first install the [napari hub Plugin Preview App](https://github.com/apps/napari-hub-plugin-preview)
+to your plugin repository, and then use this action in a workflow file, as in [this example](link-to-yml-snippet).
+
+For more detailed instructions on installing the app, adding the action to a workflow or using the preview page, you
+can refer to [this guide](link-to-main-guide).
+
+If you notice any problems using this action, please let us know by raising an issue on [this repo](https://github.com/chanzuckerberg/napari-hub-preview-action/issues/new).
 
 ## Reporting Security Issues
 To report a security issue, see [SECURITY.md](./SECURITY.md)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This GitHub action generates a napari hub plugin preview page and produces the s
 an artifact.
 
 To view your plugin as it would appear on the napari hub, first install the [napari hub Plugin Preview App](https://github.com/apps/napari-hub-plugin-preview)
-to your plugin repository, and then use this action in a workflow file, as in [this example](link-to-yml-snippet).
+to your plugin repository, and then use this action in a workflow file, as in [this example](https://github.com/chanzuckerberg/napari-hub/blob/main/docs/setting-up-preview.md#2-set-up-the-github-workflow).
 
 For more detailed instructions on installing the app, adding the action to a workflow or using the preview page, you
-can refer to [this guide](link-to-main-guide).
+can refer to [this guide](https://github.com/chanzuckerberg/napari-hub/blob/main/docs/setting-up-preview.md).
 
 If you notice any problems using this action, please let us know by raising an issue on [this repo](https://github.com/chanzuckerberg/napari-hub-preview-action/issues/new).
 


### PR DESCRIPTION
- Add instructions mentioning the preview app and action
- Link back to the main guide for setting up the preview page

TODO:
- [x] fix links once [main docs PR](https://github.com/chanzuckerberg/napari-hub/pull/318) is merged