### PR TITLE
Set up python 3 before installing requirements

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,10 @@ runs:
         ref: ${{ inputs.hub-ref }}
         repository: chanzuckerberg/napari-hub
         path: napari-hub
-
+    - name: Set up Python 3
+      uses: actions/setup-python@v2
+      with: 
+        python-version: '3.8'
     - name: Build plugin
       shell: bash
       env:


### PR DESCRIPTION
Set up Python 3.8 before installing requirements to avoid this action failing on MacOS and make sure in general we're using Python 3.