### PR TITLE
Clone & install plugin repo before discovering preview metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,10 @@ runs:
         ref: ${{ inputs.hub-ref }}
         repository: chanzuckerberg/napari-hub
         path: napari-hub
-
+    - name: Set up Python 3
+      uses: actions/setup-python@v2
+      with: 
+        python-version: '3.8'
     - name: Build plugin
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         pip install -r napari-hub/backend/requirements.txt
+        pip install npe2
         python napari-hub/backend/get_preview.py --local --branch ${{ github.head_ref }} . .
 
     - name: Copy plugin json to hub frontend repo

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Clone plugin repo
+      uses: actions/checkout@v2
+      with:
+        path: plugin
     - name: Clone napari hub repo
       uses: actions/checkout@v2
       with:
@@ -20,6 +24,13 @@ runs:
       uses: actions/setup-python@v2
       with: 
         python-version: '3.8'
+    - name: Install plugin
+      shell: bash
+      run: |
+        pip install -e ./plugin
+        # push this to a branch on my origin
+        # try to use this action from this branch, with hub ref to my branched dev lambda and see if the preview-meta builds
+        # check out the build artifact on that action run
     - name: Build plugin
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -28,9 +28,6 @@ runs:
       shell: bash
       run: |
         pip install -e ./plugin
-        # push this to a branch on my origin
-        # try to use this action from this branch, with hub ref to my branched dev lambda and see if the preview-meta builds
-        # check out the build artifact on that action run
     - name: Build plugin
       shell: bash
       env:


### PR DESCRIPTION
This PR updates the action to first install the user's plugin before trying to discover metadata.

This allows us to ensure the plugin is installed in a separate session to the Python session that discovers it, making it easier for us to discover the npe2 manifest, and making the process more robust.