### PR TITLE
Install npe2 dependency to support manifest discovery

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,10 @@ runs:
         ref: ${{ inputs.hub-ref }}
         repository: chanzuckerberg/napari-hub
         path: napari-hub
-
+    - name: Set up Python 3
+      uses: actions/setup-python@v2
+      with: 
+        python-version: '3.8'
     - name: Build plugin
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -24,8 +24,10 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
+      # satisfying npe2 dependency here to avoid bringing it into the backend
       run: |
         pip install -r napari-hub/backend/requirements.txt
+        pip install npe2
         python napari-hub/backend/get_preview.py --local --branch ${{ github.head_ref }} . .
 
     - name: Copy plugin json to hub frontend repo


### PR DESCRIPTION
Install `npe2` during the action so that we don't have to bring the dependency into the backend but still take advantage of the discovery mechanism.