### PR TITLE
Replace deprecated set-output command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
         path: napari-hub
     - name: Set up Python 3
       uses: actions/setup-python@v2
-      with: 
+      with:
         python-version: '3.8'
     - name: Build plugin
       shell: bash
@@ -42,7 +42,7 @@ runs:
     - name: Get Yarn cache directory path
       shell: bash
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
     - name: Setup Yarn cache
       uses: actions/cache@v2


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for information on the deprecation.